### PR TITLE
another solution for handle corrupted tail

### DIFF
--- a/src/gululog_idx.erl
+++ b/src/gululog_idx.erl
@@ -596,9 +596,13 @@ open_writer_fd(FileName) ->
                 Version_
             end,
   {ok, Position} = file:position(Fd, eof),
-  %% Hopefully, this assertion never fails,
-  %% In case it happens, add a function to truncate the corrupted tail.
-  0 = (Position - 1) rem file_entry_bytes(Version), %% assert
+  case (Position - 1) rem file_entry_bytes(Version) of
+    0 ->
+      ok;
+    N ->
+      file:position(Fd, Position - N),
+      file:truncate(Fd)
+  end,
   {Version, Fd}.
 
 %% @private Get per-version file entry bytes.


### PR DESCRIPTION
another solution for handle corrupted tail.

1, truncate corrupted tail for idx when open idx write fd
2, seek write cursor and truncate content after latest logid